### PR TITLE
Patch 1 - Use correct case for PicottsProvider.SetLanguage

### DIFF
--- a/src/Providers/PicottsProvider.php
+++ b/src/Providers/PicottsProvider.php
@@ -50,13 +50,12 @@ class PicottsProvider extends AbstractProvider
      */
     public function setLanguage($language)
     {
-        $language = strtolower(trim($language));
-
         if (strlen($language) === 2) {
-            $language = "{$language}-{$language}";
+			$language = strtolower(trim($language));
+            $language = "{$language}-" . strtoupper($language);
         }
 
-        if (!preg_match("/^[a-z]{2}-[a-z]{2}$/", $language)) {
+        if (!preg_match("/^[a-z]{2}-[A-Z]{2}$/", $language)) {
             throw new \InvalidArgumentException("Unexpected language code ({$language}), codes should be 2 characters, a hyphen, and a further 2 characters");
         }
 

--- a/src/Providers/PicottsProvider.php
+++ b/src/Providers/PicottsProvider.php
@@ -56,7 +56,7 @@ class PicottsProvider extends AbstractProvider
         }
 
         if (!preg_match("/^[a-z]{2}-[A-Z]{2}$/", $language)) {
-            throw new \InvalidArgumentException("Unexpected language code ({$language}), codes should be 2 characters, a hyphen, and a further 2 characters");
+            throw new \InvalidArgumentException("Unexpected language code ({$language}), codes should be 2 characters (lower case), a hyphen, and a further 2 characters (upper case)");
         }
 
         $this->language = $language;

--- a/src/Providers/PicottsProvider.php
+++ b/src/Providers/PicottsProvider.php
@@ -51,7 +51,7 @@ class PicottsProvider extends AbstractProvider
     public function setLanguage($language)
     {
         if (strlen($language) === 2) {
-			$language = strtolower(trim($language));
+	    $language = strtolower(trim($language));
             $language = "{$language}-" . strtoupper($language);
         }
 


### PR DESCRIPTION
Used under Debian Jessie, the Picotts raised the following error, even if a correct language code used : 

> Unknown language: fr-fr
> Valid languages:
> en-US
> en-GB
> de-DE
> es-ES
> fr-FR
> it-IT
> Usage: pico2wave <words>
> -w, --wave=filename.wav     Write output to this WAV file (extension SHOULD
> be .wav)
> -l, --lang=lang             Language (default: "en-US")
> Help options:
> -?, --help                  Show this help message
> --usage                 Display brief usage message

The current code changeng the given code to lower case. The proposed correction would respect a correct case.
