### PR TITLE
Replace escapeshellarg to avoid removal of special caracters

### DIFF
--- a/src/Providers/PicottsProvider.php
+++ b/src/Providers/PicottsProvider.php
@@ -105,7 +105,7 @@ class PicottsProvider extends AbstractProvider
         $cmd = escapeshellcmd($this->pico);
         $cmd .= " --wave=" . escapeshellarg($filename);
         $cmd .= " --lang=" . escapeshellarg($this->language);
-        $cmd .= " " . escapeshellarg($text);
+        $cmd .= " '" . str_replace("'", "'\\''", $text) . "'";
 
         exec($cmd, $output, $return);
 


### PR DESCRIPTION
The escapeshellarg function is removing some UTF8 caracters from the $text string.
For example, all letter with accent, commonly used in french are removed.
My proposed fix is probably not the most elegant solution, but would work on any platform, regardless of the installed locale.