### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Providers/AbstractProviderTest.php
+++ b/tests/Providers/AbstractProviderTest.php
@@ -18,7 +18,7 @@ class AbstractProviderTest extends TestCase
     private $client;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->client = Mockery::mock(ClientInterface::class);
         $this->provider = new ExampleProvider();
@@ -26,7 +26,7 @@ class AbstractProviderTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Providers/AcapelaProviderTest.php
+++ b/tests/Providers/AcapelaProviderTest.php
@@ -18,7 +18,7 @@ class AcapelaProviderTest extends TestCase
     /** @var ClientInterface|MockInterface */
     private $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->provider = new AcapelaProvider("LOGIN", "APPLICATION", "PASSWORD");
 
@@ -27,7 +27,7 @@ class AcapelaProviderTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Providers/AmazonPollyProviderTest.php
+++ b/tests/Providers/AmazonPollyProviderTest.php
@@ -22,14 +22,14 @@ class AmazonPollyProviderTest extends TestCase
     private $client;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->client = Mockery::mock(PollyClient::class);
         $this->provider = new AmazonPollyProvider($this->client);
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Providers/GoogleProviderTest.php
+++ b/tests/Providers/GoogleProviderTest.php
@@ -18,7 +18,7 @@ class GoogleProviderTest extends TestCase
     /** @var ClientInterface|MockInterface */
     private $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->provider = new GoogleProvider();
 
@@ -27,7 +27,7 @@ class GoogleProviderTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Providers/PicottsProviderTest.php
+++ b/tests/Providers/PicottsProviderTest.php
@@ -32,14 +32,14 @@ class PicottsProviderTest extends TestCase
     private $result;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->factory = Mockery::mock(FactoryInterface::class);
         $this->result = Mockery::mock(ResultInterface::class);
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (is_string($this->binary) && is_file($this->binary)) {
             unlink($this->binary);

--- a/tests/Providers/ResponsiveVoiceProviderTest.php
+++ b/tests/Providers/ResponsiveVoiceProviderTest.php
@@ -18,7 +18,7 @@ class ResponsiveVoiceProviderTest extends TestCase
     /** @var ClientInterface|MockInterface */
     private $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->provider = new ResponsiveVoiceProvider();
 
@@ -27,7 +27,7 @@ class ResponsiveVoiceProviderTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Providers/VoiceRssProviderTest.php
+++ b/tests/Providers/VoiceRssProviderTest.php
@@ -19,7 +19,7 @@ class VoiceRssProviderTest extends TestCase
     /** @var ClientInterface|MockInterface */
     private $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->provider = new VoiceRssProvider("APIKEY");
 
@@ -28,7 +28,7 @@ class VoiceRssProviderTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/TextToSpeechTest.php
+++ b/tests/TextToSpeechTest.php
@@ -17,14 +17,14 @@ class TextToSpeechTest extends TestCase
     private $provider;
     private $tts;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->provider = Mockery::mock(ProviderInterface::class);
         $this->tts = new TextToSpeech("hello", $this->provider);
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected tearDown` methods.